### PR TITLE
Remove stray parenthesis causing regex error

### DIFF
--- a/lib/jsonpretty.rb
+++ b/lib/jsonpretty.rb
@@ -8,7 +8,7 @@ class Jsonpretty
              File.open(filename)
            end
     lines = file.readlines
-    if lines.first =~ /^HTTP\/\d)/ # looks like an HTTP response; we just want the body
+    if lines.first =~ /^HTTP\/\d/ # looks like an HTTP response; we just want the body
       index = lines.index("\r\n") || lines.index("\n")
       puts lines[0..index]
       lines[(index+1)..-1].join('')


### PR DESCRIPTION
Changing the HTTP version regex from `1\.` to `\d` also introduced a stray parenthesis causing the regex to fail to parse.